### PR TITLE
PaperMC: Install deb package 'patch'

### DIFF
--- a/Paper/buildPaper.sh
+++ b/Paper/buildPaper.sh
@@ -3,7 +3,7 @@
 
 # install git
 apt-get update
-apt-get install -y git
+apt-get install -y git patch
 
 # configure git (without paper will not build)
 git config --global user.email "docker@marcermarc.de"


### PR DESCRIPTION
According to https://github.com/PaperMC/Paper/pull/4172 the required
packages to build PaperMC now are git, mvn, javac and patch.